### PR TITLE
Implement forbidden stances + config modal rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,3 @@ Missing features (so far):
 - Correctly restricted character creation options. Boss archetypes in particular require that a certain style is used, but this isn't enforced.
 - Alternate rules (e.g. endless stooges)
 - overarching DM tools, like a round/turn tracker
-- Forbidden style. the style text is there, but selecting two forms is not implemented.

--- a/src/app/components/ConfigModal.tsx
+++ b/src/app/components/ConfigModal.tsx
@@ -26,7 +26,7 @@ const boxStyle = {
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  width: "80%",
+  width: "60%",
   bgcolor: "background.paper",
   boxShadow: 24,
 }

--- a/src/app/components/config/BossConfig.tsx
+++ b/src/app/components/config/BossConfig.tsx
@@ -1,7 +1,11 @@
 import {
   Divider,
+  FormControl,
+  FormGroup,
+  FormHelperText,
   MenuItem,
   Select,
+  Stack,
   Table,
   TableCell,
   TableRow,
@@ -16,6 +20,7 @@ import {
   setType,
 } from "../../../features/hero/heroSlice"
 import { archetypes, bossArchetypes, forms, styles } from "../../textContent"
+import { FormSelector, StyleSelector } from "./selectors"
 
 const ArchetypeSelector = () => {
   const hero = useAppSelector(state => state.hero.hero)
@@ -43,53 +48,6 @@ const ArchetypeSelector = () => {
   )
 }
 
-const StyleSelectors = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
-
-  const handleDisabled = (style: Style) => hero.styles.includes(style)
-
-  return hero.styles.map((style, i) => (
-    <TableCell align="center">
-      <Select
-        value={style.name}
-        onChange={e => {
-          dispatch(setStyle({ styleName: e.target.value, number: i }))
-        }}
-      >
-        {styles.map(s => (
-          <MenuItem key={s.name} value={s.name} disabled={handleDisabled(s)}>
-            {s.name}
-          </MenuItem>
-        ))}
-      </Select>
-    </TableCell>
-  ))
-}
-
-const FormSelectors = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
-
-  const handleDisabled = (form: Form) => hero.forms.includes(form)
-
-  return hero.forms.map((form, i) => (
-    <TableCell align="center">
-      <Select
-        value={form.name}
-        onChange={e => {
-          dispatch(setForm({ formName: e.target.value, number: i }))
-        }}
-      >
-        {forms.map(f => (
-          <MenuItem key={f.name} value={f.name} disabled={handleDisabled(f)}>
-            {f.name}
-          </MenuItem>
-        ))}
-      </Select>
-    </TableCell>
-  ))
-}
 export const BossConfig = () => {
   return (
     <>
@@ -102,14 +60,20 @@ export const BossConfig = () => {
         </TableRow>
       </Table>
       <Divider>Stances</Divider>
-      <Table>
-        <TableRow>
-          <StyleSelectors />
-        </TableRow>
-        <TableRow>
-          <FormSelectors />
-        </TableRow>
-      </Table>
+      <Stack spacing={1} direction={"row"}>
+        {[0, 1, 2].map((i) =>
+          <FormGroup className="stanceFormGroup">
+            <FormControl sx={{ m: 1 }}>
+              <StyleSelector fromArchetypes={[]} index={i} />
+              <FormHelperText>Style {i + 1}</FormHelperText>
+            </FormControl>
+            <FormControl sx={{ m: 1 }}>
+              <FormSelector index={i} />
+              <FormHelperText>Form {i + 1}</FormHelperText>
+            </FormControl>
+          </FormGroup>
+        )}
+      </Stack>
     </>
   )
 }

--- a/src/app/components/config/BossConfig.tsx
+++ b/src/app/components/config/BossConfig.tsx
@@ -1,26 +1,11 @@
 import {
-  Divider,
   FormControl,
   FormGroup,
   FormHelperText,
   FormLabel,
-  ListSubheader,
-  MenuItem,
-  Select,
   Stack,
-  Table,
-  TableCell,
-  TableRow,
 } from "@mui/material"
-import { useAppDispatch, useAppSelector } from "../../hooks"
-import { HeroType } from "../../types"
-import {
-  setArchetype,
-  setType,
-} from "../../../features/hero/heroSlice"
-import { archetypes, bossArchetypes } from "../../textContent"
 import { ArchetypeSelector, FormSelector, StyleSelector } from "./selectors"
-
 
 export const BossConfig = () => {
   return (
@@ -30,7 +15,7 @@ export const BossConfig = () => {
         <ArchetypeSelector includeUnselected index={0} />
       </FormGroup>
       <Stack spacing={1} direction={"row"}>
-        {[0, 1, 2].map((i) =>
+        {[0, 1, 2].map(i => (
           <FormGroup className="stanceFormGroup">
             <FormControl sx={{ m: 1 }}>
               <StyleSelector fromArchetypes={[]} index={i} />
@@ -41,7 +26,7 @@ export const BossConfig = () => {
               <FormHelperText>Form {i + 1}</FormHelperText>
             </FormControl>
           </FormGroup>
-        )}
+        ))}
       </Stack>
     </>
   )

--- a/src/app/components/config/BossConfig.tsx
+++ b/src/app/components/config/BossConfig.tsx
@@ -3,6 +3,7 @@ import {
   FormControl,
   FormGroup,
   FormHelperText,
+  FormLabel,
   ListSubheader,
   MenuItem,
   Select,
@@ -18,52 +19,16 @@ import {
   setType,
 } from "../../../features/hero/heroSlice"
 import { archetypes, bossArchetypes } from "../../textContent"
-import { FormSelector, StyleSelector } from "./selectors"
+import { ArchetypeSelector, FormSelector, StyleSelector } from "./selectors"
 
-const ArchetypeSelector = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
-  return (
-    <Select
-      value={hero.archetypes[0].name}
-      onChange={e => {
-        dispatch(
-          setArchetype({
-            archetypeName: e.target.value,
-            number: 0,
-          }),
-        )
-        dispatch(setType(HeroType.Fused))
-      }}
-    >
-      <ListSubheader>General</ListSubheader>
-      {archetypes.map(arch => (
-        <MenuItem key={arch.name} value={arch.name}>
-          {arch.name}
-        </MenuItem>
-      ))}
-      <ListSubheader>Boss Archetypes</ListSubheader>
-      {bossArchetypes.map(arch => (
-        <MenuItem key={arch.name} value={arch.name}>
-          {arch.name}
-        </MenuItem>
-      ))}
-    </Select>
-  )
-}
 
 export const BossConfig = () => {
   return (
     <>
-      <Table>
-        <TableRow>
-          <TableCell align="right">Archetype:</TableCell>
-          <TableCell>
-            <ArchetypeSelector />
-          </TableCell>
-        </TableRow>
-      </Table>
-      <Divider>Stances</Divider>
+      <FormGroup>
+        <FormLabel>Archetype</FormLabel>
+        <ArchetypeSelector includeUnselected index={0} />
+      </FormGroup>
       <Stack spacing={1} direction={"row"}>
         {[0, 1, 2].map((i) =>
           <FormGroup className="stanceFormGroup">

--- a/src/app/components/config/BossConfig.tsx
+++ b/src/app/components/config/BossConfig.tsx
@@ -3,6 +3,7 @@ import {
   FormControl,
   FormGroup,
   FormHelperText,
+  ListSubheader,
   MenuItem,
   Select,
   Stack,
@@ -11,21 +12,17 @@ import {
   TableRow,
 } from "@mui/material"
 import { useAppDispatch, useAppSelector } from "../../hooks"
-import type { Form, Style } from "../../types"
 import { HeroType } from "../../types"
 import {
   setArchetype,
-  setForm,
-  setStyle,
   setType,
 } from "../../../features/hero/heroSlice"
-import { archetypes, bossArchetypes, forms, styles } from "../../textContent"
+import { archetypes, bossArchetypes } from "../../textContent"
 import { FormSelector, StyleSelector } from "./selectors"
 
 const ArchetypeSelector = () => {
   const hero = useAppSelector(state => state.hero.hero)
   const dispatch = useAppDispatch()
-  const options = [...archetypes, ...bossArchetypes]
   return (
     <Select
       value={hero.archetypes[0].name}
@@ -39,7 +36,14 @@ const ArchetypeSelector = () => {
         dispatch(setType(HeroType.Fused))
       }}
     >
-      {options.map(arch => (
+      <ListSubheader>General</ListSubheader>
+      {archetypes.map(arch => (
+        <MenuItem key={arch.name} value={arch.name}>
+          {arch.name}
+        </MenuItem>
+      ))}
+      <ListSubheader>Boss Archetypes</ListSubheader>
+      {bossArchetypes.map(arch => (
         <MenuItem key={arch.name} value={arch.name}>
           {arch.name}
         </MenuItem>

--- a/src/app/components/config/StoogeConfig.tsx
+++ b/src/app/components/config/StoogeConfig.tsx
@@ -1,12 +1,9 @@
-import { MenuItem, Select, Table, TableCell, TableRow } from "@mui/material"
+import { FormControl, FormGroup, FormHelperText, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
 import { BuildSelector } from "./BuildSelector"
 import { useAppDispatch, useAppSelector } from "../../hooks"
-import { archetypes, defaultArchetype, forms, styles } from "../../textContent"
-import {
-  setArchetype,
-  setForm,
-  setStyle,
-} from "../../../features/hero/heroSlice"
+import { archetypes, defaultArchetype } from "../../textContent"
+import { setArchetype } from "../../../features/hero/heroSlice"
+import { FormSelector, StyleSelector } from "./selectors"
 
 const ArchetypeSelector = () => {
   const hero = useAppSelector(state => state.hero.hero)
@@ -34,47 +31,9 @@ const ArchetypeSelector = () => {
   )
 }
 
-const FormSelector = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
-
-  const form = hero.forms[0]
-  return (
-    <Select
-      value={form.name}
-      onChange={e => {
-        dispatch(setForm({ formName: e.target.value, number: 0 }))
-      }}
-    >
-      {forms.map(f => (
-        <MenuItem key={f.name} value={f.name}>
-          {f.name}
-        </MenuItem>
-      ))}
-    </Select>
-  )
-}
-const StyleSelector = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
-
-  return (
-    <Select
-      value={hero.styles[0].name}
-      onChange={e => {
-        dispatch(setStyle({ styleName: e.target.value, number: 0 }))
-      }}
-    >
-      {styles.map(s => (
-        <MenuItem key={s.name} value={s.name}>
-          {s.name}
-        </MenuItem>
-      ))}
-    </Select>
-  )
-}
 
 export const StoogeConfig = () => {
+  const hero = useAppSelector(state => state.hero.hero)
   return (
     <Table>
       <TableRow>
@@ -90,16 +49,20 @@ export const StoogeConfig = () => {
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell align="right">Style: </TableCell>
-        <TableCell>
-          <StyleSelector />
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell align="right">Form: </TableCell>
-        <TableCell>
-          <FormSelector />
-        </TableCell>
+        <Stack spacing={1} direction={"row"}>
+          <FormGroup className="stanceFormGroup">
+            <FormControl sx={{ m: 1 }}>
+              <StyleSelector fromArchetypes={[hero.archetypes[0]]} index={0} />
+              <FormHelperText>
+                Style 1
+              </FormHelperText>
+            </FormControl>
+            <FormControl sx={{ m: 1 }}>
+              <FormSelector index={0} />
+              <FormHelperText>Form 1</FormHelperText>
+            </FormControl>
+          </FormGroup>
+        </Stack>
       </TableRow>
     </Table>
   )

--- a/src/app/components/config/StoogeConfig.tsx
+++ b/src/app/components/config/StoogeConfig.tsx
@@ -1,69 +1,23 @@
-import { FormControl, FormGroup, FormHelperText, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
+import { FormControl, FormControlLabel, FormGroup, FormHelperText, FormLabel, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
 import { BuildSelector } from "./BuildSelector"
 import { useAppDispatch, useAppSelector } from "../../hooks"
 import { archetypes, defaultArchetype } from "../../textContent"
 import { setArchetype } from "../../../features/hero/heroSlice"
-import { FormSelector, StyleSelector } from "./selectors"
-
-const ArchetypeSelector = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
-  const options = [defaultArchetype, ...archetypes]
-
-  return (
-    <Select
-      value={hero.archetypes[0].name}
-      onChange={e => {
-        dispatch(
-          setArchetype({
-            archetypeName: e.target.value,
-            number: 0,
-          }),
-        )
-      }}
-    >
-      {options.map(arch => (
-        <MenuItem key={arch.name} value={arch.name}>
-          {arch.name}
-        </MenuItem>
-      ))}
-    </Select>
-  )
-}
+import { ArchetypeSelector, FormSelector, StyleSelector } from "./selectors"
 
 
 export const StoogeConfig = () => {
   const hero = useAppSelector(state => state.hero.hero)
   return (
-    <Table>
-      <TableRow>
-        <TableCell align="right">Build:</TableCell>
-        <TableCell>
-          <BuildSelector />
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell align="right">Archetype (Super Stooges only): </TableCell>
-        <TableCell>
-          <ArchetypeSelector />
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <Stack spacing={1} direction={"row"}>
-          <FormGroup className="stanceFormGroup">
-            <FormControl sx={{ m: 1 }}>
-              <StyleSelector fromArchetypes={[hero.archetypes[0]]} index={0} />
-              <FormHelperText>
-                Style 1
-              </FormHelperText>
-            </FormControl>
-            <FormControl sx={{ m: 1 }}>
-              <FormSelector index={0} />
-              <FormHelperText>Form 1</FormHelperText>
-            </FormControl>
-          </FormGroup>
-        </Stack>
-      </TableRow>
-    </Table>
+    <FormGroup>
+      <FormLabel>Build</FormLabel>
+      <BuildSelector />
+      <FormLabel>Archetype (Super Stooges only)</FormLabel>
+      <ArchetypeSelector includeUnselected index={0} />
+      <FormLabel>Style</FormLabel>
+      <StyleSelector fromArchetypes={[hero.archetypes[0]]} index={0} />
+      <FormLabel>Form</FormLabel>
+      <FormSelector index={0} />
+    </FormGroup>
   )
 }

--- a/src/app/components/config/StoogeConfig.tsx
+++ b/src/app/components/config/StoogeConfig.tsx
@@ -1,10 +1,7 @@
-import { FormControl, FormControlLabel, FormGroup, FormHelperText, FormLabel, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
+import { FormGroup, FormLabel } from "@mui/material"
 import { BuildSelector } from "./BuildSelector"
-import { useAppDispatch, useAppSelector } from "../../hooks"
-import { archetypes, defaultArchetype } from "../../textContent"
-import { setArchetype } from "../../../features/hero/heroSlice"
+import { useAppSelector } from "../../hooks"
 import { ArchetypeSelector, FormSelector, StyleSelector } from "./selectors"
-
 
 export const StoogeConfig = () => {
   const hero = useAppSelector(state => state.hero.hero)

--- a/src/app/components/config/WarriorConfig.tsx
+++ b/src/app/components/config/WarriorConfig.tsx
@@ -1,9 +1,6 @@
-import { FormControl, FormGroup, FormHelperText, FormLabel, ListSubheader, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
-import { useAppDispatch, useAppSelector } from "../../hooks"
-
+import { FormGroup, FormLabel } from "@mui/material"
+import { useAppSelector } from "../../hooks"
 import { ArchetypeSelector, FormSelector, StyleSelector } from "./selectors"
-
-
 
 export const WarriorConfig = () => {
   const hero = useAppSelector(state => state.hero.hero)

--- a/src/app/components/config/WarriorConfig.tsx
+++ b/src/app/components/config/WarriorConfig.tsx
@@ -1,13 +1,9 @@
-import { MenuItem, Select, Table, TableCell, TableRow } from "@mui/material"
+import { FormControl, FormGroup, FormHelperText, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
 import { useAppDispatch, useAppSelector } from "../../hooks"
-import { archetypes, bossArchetypes, forms, styles } from "../../textContent"
-import {
-  setArchetype,
-  setForm,
-  setStyle,
-  setType,
-} from "../../../features/hero/heroSlice"
+import { archetypes, bossArchetypes } from "../../textContent"
+import { setArchetype, setType } from "../../../features/hero/heroSlice"
 import { HeroType } from "../../types"
+import { FormSelector, StyleSelector } from "./selectors"
 
 const ArchetypeSelector = () => {
   const hero = useAppSelector(state => state.hero.hero)
@@ -36,50 +32,8 @@ const ArchetypeSelector = () => {
   )
 }
 
-const FormSelector = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
-
-  const form = hero.forms[0]
-  return (
-    <Select
-      value={form.name}
-      onChange={e => {
-        dispatch(setForm({ formName: e.target.value, number: 0 }))
-      }}
-    >
-      {forms.map(f => (
-        <MenuItem key={f.name} value={f.name}>
-          {f.name}
-        </MenuItem>
-      ))}
-    </Select>
-  )
-}
-const StyleSelector = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
-
-  const availableStyles = styles.filter(s =>
-    hero.archetypes.map(a => a.name).includes(s.parentArchetypeName),
-  )
-  return (
-    <Select
-      value={hero.styles[0].name}
-      onChange={e => {
-        dispatch(setStyle({ styleName: e.target.value, number: 0 }))
-      }}
-    >
-      {availableStyles.map(s => (
-        <MenuItem key={s.name} value={s.name}>
-          {s.name}
-        </MenuItem>
-      ))}
-    </Select>
-  )
-}
-
 export const WarriorConfig = () => {
+  const hero = useAppSelector(state => state.hero.hero)
   return (
     <Table>
       <TableRow>
@@ -89,16 +43,18 @@ export const WarriorConfig = () => {
         </TableCell>
       </TableRow>
       <TableRow>
-        <TableCell align="right">Style: </TableCell>
-        <TableCell>
-          <StyleSelector />
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell align="right">Form: </TableCell>
-        <TableCell>
-          <FormSelector />
-        </TableCell>
+        <Stack spacing={1} direction={"row"}>
+          <FormGroup className="stanceFormGroup">
+            <FormControl sx={{ m: 1 }}>
+              <StyleSelector fromArchetypes={[hero.archetypes[0]]} index={0} />
+              <FormHelperText>Style 1</FormHelperText>
+            </FormControl>
+            <FormControl sx={{ m: 1 }}>
+              <FormSelector index={0} />
+              <FormHelperText>Form 1</FormHelperText>
+            </FormControl>
+          </FormGroup>
+        </Stack>
       </TableRow>
     </Table>
   )

--- a/src/app/components/config/WarriorConfig.tsx
+++ b/src/app/components/config/WarriorConfig.tsx
@@ -1,67 +1,20 @@
-import { FormControl, FormGroup, FormHelperText, ListSubheader, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
+import { FormControl, FormGroup, FormHelperText, FormLabel, ListSubheader, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
 import { useAppDispatch, useAppSelector } from "../../hooks"
-import { archetypes, bossArchetypes } from "../../textContent"
-import { setArchetype, setType } from "../../../features/hero/heroSlice"
-import { HeroType } from "../../types"
-import { FormSelector, StyleSelector } from "./selectors"
 
-const ArchetypeSelector = () => {
-  const hero = useAppSelector(state => state.hero.hero)
-  const dispatch = useAppDispatch()
+import { ArchetypeSelector, FormSelector, StyleSelector } from "./selectors"
 
-  return (
-    <Select
-      value={hero.archetypes[0].name}
-      onChange={e => {
-        dispatch(
-          setArchetype({
-            archetypeName: e.target.value,
-            number: 0,
-          }),
-          dispatch(setType(HeroType.Fused)),
-        )
-      }}
-    >
-      <ListSubheader>General</ListSubheader>
-      {archetypes.map(arch => (
-        <MenuItem key={arch.name} value={arch.name}>
-          {arch.name}
-        </MenuItem>
-      ))}
-      <ListSubheader>Boss Archetypes</ListSubheader>
-      {bossArchetypes.map(arch => (
-        <MenuItem key={arch.name} value={arch.name}>
-          {arch.name}
-        </MenuItem>
-      ))}
-    </Select>
-  )
-}
+
 
 export const WarriorConfig = () => {
   const hero = useAppSelector(state => state.hero.hero)
   return (
-    <Table>
-      <TableRow>
-        <TableCell align="right">Archetype: </TableCell>
-        <TableCell>
-          <ArchetypeSelector />
-        </TableCell>
-      </TableRow>
-      <TableRow>
-        <Stack spacing={1} direction={"row"}>
-          <FormGroup className="stanceFormGroup">
-            <FormControl sx={{ m: 1 }}>
-              <StyleSelector fromArchetypes={[hero.archetypes[0]]} index={0} />
-              <FormHelperText>Style 1</FormHelperText>
-            </FormControl>
-            <FormControl sx={{ m: 1 }}>
-              <FormSelector index={0} />
-              <FormHelperText>Form 1</FormHelperText>
-            </FormControl>
-          </FormGroup>
-        </Stack>
-      </TableRow>
-    </Table>
+    <FormGroup>
+      <FormLabel>Archetype</FormLabel>
+      <ArchetypeSelector includeBossArchetypes index={0} />
+      <FormLabel>Style</FormLabel>
+      <StyleSelector fromArchetypes={[hero.archetypes[0]]} index={0} />
+      <FormLabel>Form</FormLabel>
+      <FormSelector index={0} />
+    </FormGroup>
   )
 }

--- a/src/app/components/config/WarriorConfig.tsx
+++ b/src/app/components/config/WarriorConfig.tsx
@@ -1,4 +1,4 @@
-import { FormControl, FormGroup, FormHelperText, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
+import { FormControl, FormGroup, FormHelperText, ListSubheader, MenuItem, Select, Stack, Table, TableCell, TableRow } from "@mui/material"
 import { useAppDispatch, useAppSelector } from "../../hooks"
 import { archetypes, bossArchetypes } from "../../textContent"
 import { setArchetype, setType } from "../../../features/hero/heroSlice"
@@ -8,7 +8,6 @@ import { FormSelector, StyleSelector } from "./selectors"
 const ArchetypeSelector = () => {
   const hero = useAppSelector(state => state.hero.hero)
   const dispatch = useAppDispatch()
-  const options = [...archetypes, ...bossArchetypes]
 
   return (
     <Select
@@ -23,7 +22,14 @@ const ArchetypeSelector = () => {
         )
       }}
     >
-      {options.map(arch => (
+      <ListSubheader>General</ListSubheader>
+      {archetypes.map(arch => (
+        <MenuItem key={arch.name} value={arch.name}>
+          {arch.name}
+        </MenuItem>
+      ))}
+      <ListSubheader>Boss Archetypes</ListSubheader>
+      {bossArchetypes.map(arch => (
         <MenuItem key={arch.name} value={arch.name}>
           {arch.name}
         </MenuItem>

--- a/src/app/components/config/hero/HeroConfig.tsx
+++ b/src/app/components/config/hero/HeroConfig.tsx
@@ -1,11 +1,4 @@
-import {
-  Divider,
-  MenuItem,
-  Select,
-  Table,
-  TableCell,
-  TableRow,
-} from "@mui/material"
+import { Divider, FormGroup, FormLabel, MenuItem, Select } from "@mui/material"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import { HeroType } from "../../../types"
 import { setArchetype, setType } from "../../../../features/hero/heroSlice"
@@ -14,6 +7,7 @@ import { BuildSelector } from "../BuildSelector"
 import { FocusedStances } from "./focusedStances"
 import { FusedStances } from "./fusedStances"
 import { FranticStances } from "./franticStances"
+import "./HeroConfig.css"
 
 const ArchetypeSelectors = () => {
   const hero = useAppSelector(state => state.hero.hero)
@@ -35,31 +29,33 @@ const ArchetypeSelectors = () => {
   const selectedArchetypes = allHeroArchetypes.filter(
     a => a !== defaultArchetype,
   )
-  return allHeroArchetypes.map((a, i) => (
-    <span className="archetypeSelectors">
-      <Select
-        value={a.name}
-        onChange={e => {
-          dispatch(
-            setArchetype({
-              archetypeName: e.target.value,
-              number: i,
-            }),
-          )
-        }}
-      >
-        {archetypes.map(arch => (
-          <MenuItem
-            key={arch.name}
-            value={arch.name}
-            disabled={selectedArchetypes.includes(arch)}
-          >
-            {arch.name}
-          </MenuItem>
-        ))}
-      </Select>
-    </span>
-  ))
+  return (
+    <FormGroup className="archetypeSelectors">
+      {allHeroArchetypes.map((a, i) => (
+        <Select
+          value={a.name}
+          onChange={e => {
+            dispatch(
+              setArchetype({
+                archetypeName: e.target.value,
+                number: i,
+              }),
+            )
+          }}
+        >
+          {archetypes.map(arch => (
+            <MenuItem
+              key={arch.name}
+              value={arch.name}
+              disabled={selectedArchetypes.includes(arch)}
+            >
+              {arch.name}
+            </MenuItem>
+          ))}
+        </Select>
+      ))}
+    </FormGroup>
+  )
 }
 
 export const HeroConfig = () => {
@@ -95,24 +91,14 @@ export const HeroConfig = () => {
   }
   return (
     <>
-      <Table>
-        <TableRow>
-          <TableCell align="right">Build:</TableCell>
-          <TableCell>
-            <BuildSelector />
-          </TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell align="right">Hero Type:</TableCell>
-          <TableCell>{heroTypeSelector}</TableCell>
-        </TableRow>
-        <TableRow>
-          <TableCell align="right">Archetypes:</TableCell>
-          <TableCell>
-            <ArchetypeSelectors />
-          </TableCell>
-        </TableRow>
-      </Table>
+      <FormGroup>
+        <FormLabel>Build</FormLabel>
+        <BuildSelector />
+        <FormLabel>Hero Type</FormLabel>
+        {heroTypeSelector}
+        <FormLabel>Archetypes</FormLabel>
+        <ArchetypeSelectors />
+      </FormGroup>
       <Divider>Stances</Divider>
       {stanceComponent}
     </>

--- a/src/app/components/config/hero/focusedStances.tsx
+++ b/src/app/components/config/hero/focusedStances.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormGroup, FormHelperText, Stack } from "@mui/material"
 import { useAppSelector } from "../../../hooks"
-import { FormSelector, StyleSelector } from "./selectors"
+import { FormSelector, StyleSelector } from "../selectors"
 import "./stances.css"
 
 export const FocusedStances = () => {

--- a/src/app/components/config/hero/franticStances.tsx
+++ b/src/app/components/config/hero/franticStances.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormGroup, FormHelperText, Stack } from "@mui/material"
 import { useAppSelector } from "../../../hooks"
-import { FormSelector, StyleSelector } from "./selectors"
+import { FormSelector, StyleSelector } from "../selectors"
 import { archetypes, defaultArchetype } from "../../../textContent"
 import type { Archetype } from "../../../types"
 import "./stances.css"

--- a/src/app/components/config/hero/fusedStances.tsx
+++ b/src/app/components/config/hero/fusedStances.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormGroup, FormHelperText, Stack } from "@mui/material"
 import { useAppSelector } from "../../../hooks"
-import { FormSelector, StyleSelector } from "./selectors"
+import { FormSelector, StyleSelector } from "../selectors"
 import "./stances.css"
 
 export const FusedStances = () => {

--- a/src/app/components/config/hero/selectors.tsx
+++ b/src/app/components/config/hero/selectors.tsx
@@ -1,19 +1,26 @@
 import { ListSubheader, MenuItem, Select } from "@mui/material"
-import { setForm, setStyle } from "../../../../features/hero/heroSlice"
+import {
+  combineForms,
+  setForm,
+  setStyle,
+  splitForms,
+} from "../../../../features/hero/heroSlice"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import type { Archetype, Form, Style } from "../../../types"
 import {
   archetypes,
   defaultArchetype,
+  defaultForm,
   forms,
   styles,
 } from "../../../textContent"
+import { useState } from "react"
 
-export const FormSelector = ({ index }: { index: number }) => {
+const SingleFormSelector = ({ index }: { index: number }) => {
   const hero = useAppSelector(state => state.hero.hero)
   const dispatch = useAppDispatch()
-
   const handleDisabled = (form: Form) => hero.forms.includes(form)
+
   return (
     <Select
       value={hero.forms[index].name}
@@ -27,6 +34,79 @@ export const FormSelector = ({ index }: { index: number }) => {
         </MenuItem>
       ))}
     </Select>
+  )
+}
+
+/**
+ * Component for building/setting forbidden forms.
+ * uses local state to select the two sub-forms, then percolates that to redux state when both are selected
+ */
+const ForbiddenFormSelector = ({ index }: { index: number }) => {
+  const hero = useAppSelector(state => state.hero.hero)
+  const dispatch = useAppDispatch()
+
+  const handleDisabled = (form: Form) => hero.forms.includes(form)
+
+  const handleGlobalStateChange = (form1: Form, form2: Form) => {
+    if (form1 !== defaultForm && form2 !== defaultForm) {
+      const forbiddenForm = combineForms(form1, form2)
+      dispatch(setForm({ form: forbiddenForm, number: index }))
+    }
+  }
+
+  const [prefill1, prefill2] = splitForms(hero.forms[index].key)
+  const [form1, setForm1] = useState(prefill1 ?? hero.forms[index])
+  const [form2, setForm2] = useState(prefill2 ?? defaultForm)
+
+  return (
+    <>
+      <Select
+        value={form1.name}
+        onChange={e => {
+          const found =
+            forms.find(f => f.name === e.target.value) ?? defaultForm
+          setForm1(found)
+          handleGlobalStateChange(found, form2)
+        }}
+      >
+        {forms.map(f => (
+          <MenuItem key={f.name} value={f.name} disabled={handleDisabled(f)}>
+            {f.name}
+          </MenuItem>
+        ))}
+      </Select>
+      <Select
+        value={form2.name}
+        onChange={e => {
+          const found =
+            forms.find(f => f.name === e.target.value) ?? defaultForm
+          setForm2(found)
+          handleGlobalStateChange(form1, found)
+        }}
+      >
+        {forms.map(f => (
+          <MenuItem key={f.name} value={f.name} disabled={handleDisabled(f)}>
+            {f.name}
+          </MenuItem>
+        ))}
+      </Select>
+    </>
+  )
+}
+export const FormSelector = ({ index }: { index: number }) => {
+  const hero = useAppSelector(state => state.hero.hero)
+
+  const pairedStyle = hero.styles[index]
+  const showForbiddenSelector = pairedStyle.key === "56"
+
+  return (
+    <>
+      {showForbiddenSelector ? (
+        <ForbiddenFormSelector index={index} />
+      ) : (
+        <SingleFormSelector index={index} />
+      )}
+    </>
   )
 }
 

--- a/src/app/components/config/selectors.tsx
+++ b/src/app/components/config/selectors.tsx
@@ -4,16 +4,16 @@ import {
   setForm,
   setStyle,
   splitForms,
-} from "../../../../features/hero/heroSlice"
-import { useAppDispatch, useAppSelector } from "../../../hooks"
-import type { Archetype, Form, Style } from "../../../types"
+} from "../../../features/hero/heroSlice"
+import { useAppDispatch, useAppSelector } from "../../hooks"
+import type { Archetype, Form, Style } from "../../types"
 import {
   archetypes,
   defaultArchetype,
   defaultForm,
   forms,
   styles,
-} from "../../../textContent"
+} from "../../textContent"
 import { useState } from "react"
 
 const SingleFormSelector = ({ index }: { index: number }) => {

--- a/src/app/components/config/selectors.tsx
+++ b/src/app/components/config/selectors.tsx
@@ -18,15 +18,15 @@ import {
 } from "../../textContent"
 import { useState } from "react"
 
-const ITEM_HEIGHT = 48;
-const ITEM_PADDING_TOP = 8;
+const ITEM_HEIGHT = 48
+const ITEM_PADDING_TOP = 8
 const MenuProps = {
   PaperProps: {
     style: {
       maxHeight: ITEM_HEIGHT * 5.5 + ITEM_PADDING_TOP,
     },
   },
-};
+}
 
 const SingleFormSelector = ({ index }: { index: number }) => {
   const hero = useAppSelector(state => state.hero.hero)
@@ -82,7 +82,6 @@ const ForbiddenFormSelector = ({ index }: { index: number }) => {
           handleGlobalStateChange(found, form2)
         }}
         MenuProps={MenuProps}
-
       >
         {forms.map(f => (
           <MenuItem key={f.name} value={f.name} disabled={handleDisabled(f)}>
@@ -105,7 +104,6 @@ const ForbiddenFormSelector = ({ index }: { index: number }) => {
             {f.name}
           </MenuItem>
         ))}
-
       </Select>
     </>
   )
@@ -170,7 +168,15 @@ export const StyleSelector = ({
   )
 }
 
-export const ArchetypeSelector = ({ index, includeBossArchetypes = false, includeUnselected = false }: { index: number, includeBossArchetypes?: boolean, includeUnselected?: boolean }) => {
+export const ArchetypeSelector = ({
+  index,
+  includeBossArchetypes = false,
+  includeUnselected = false,
+}: {
+  index: number
+  includeBossArchetypes?: boolean
+  includeUnselected?: boolean
+}) => {
   const hero = useAppSelector(state => state.hero.hero)
   const dispatch = useAppDispatch()
 
@@ -187,12 +193,10 @@ export const ArchetypeSelector = ({ index, includeBossArchetypes = false, includ
   ))
   if (includeUnselected) {
     menuItems = [
-      <MenuItem
-        key={defaultArchetype.name}
-        value={defaultArchetype.name}
-      >
+      <MenuItem key={defaultArchetype.name} value={defaultArchetype.name}>
         No Archetype
-      </MenuItem>, ...menuItems
+      </MenuItem>,
+      ...menuItems,
     ]
   }
   if (includeBossArchetypes) {
@@ -201,19 +205,27 @@ export const ArchetypeSelector = ({ index, includeBossArchetypes = false, includ
         {arch.name}
       </MenuItem>
     ))
-    menuItems = [<ListSubheader>General</ListSubheader>, ...menuItems, <ListSubheader>Boss Archetypes</ListSubheader>, ...bossMenuItems]
+    menuItems = [
+      <ListSubheader>General</ListSubheader>,
+      ...menuItems,
+      <ListSubheader>Boss Archetypes</ListSubheader>,
+      ...bossMenuItems,
+    ]
   }
-  return (<Select
-    value={archetype.name}
-    onChange={e => {
-      dispatch(
-        setArchetype({
-          archetypeName: e.target.value,
-          number: index,
-        }),
-      )
-    }}
-  >
-    {menuItems}
-  </Select>)
+  return (
+    <Select
+      value={archetype.name}
+      onChange={e => {
+        dispatch(
+          setArchetype({
+            archetypeName: e.target.value,
+            number: index,
+          }),
+        )
+      }}
+      MenuProps={MenuProps}
+    >
+      {menuItems}
+    </Select>
+  )
 }

--- a/src/app/components/config/selectors.tsx
+++ b/src/app/components/config/selectors.tsx
@@ -1,6 +1,7 @@
 import { ListSubheader, MenuItem, Select } from "@mui/material"
 import {
   combineForms,
+  setArchetype,
   setForm,
   setStyle,
   splitForms,
@@ -9,12 +10,23 @@ import { useAppDispatch, useAppSelector } from "../../hooks"
 import type { Archetype, Form, Style } from "../../types"
 import {
   archetypes,
+  bossArchetypes,
   defaultArchetype,
   defaultForm,
   forms,
   styles,
 } from "../../textContent"
 import { useState } from "react"
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 5.5 + ITEM_PADDING_TOP,
+    },
+  },
+};
 
 const SingleFormSelector = ({ index }: { index: number }) => {
   const hero = useAppSelector(state => state.hero.hero)
@@ -27,6 +39,7 @@ const SingleFormSelector = ({ index }: { index: number }) => {
       onChange={e => {
         dispatch(setForm({ formName: e.target.value, number: index }))
       }}
+      MenuProps={MenuProps}
     >
       {forms.map(f => (
         <MenuItem key={f.name} value={f.name} disabled={handleDisabled(f)}>
@@ -68,6 +81,8 @@ const ForbiddenFormSelector = ({ index }: { index: number }) => {
           setForm1(found)
           handleGlobalStateChange(found, form2)
         }}
+        MenuProps={MenuProps}
+
       >
         {forms.map(f => (
           <MenuItem key={f.name} value={f.name} disabled={handleDisabled(f)}>
@@ -83,12 +98,14 @@ const ForbiddenFormSelector = ({ index }: { index: number }) => {
           setForm2(found)
           handleGlobalStateChange(form1, found)
         }}
+        MenuProps={MenuProps}
       >
         {forms.map(f => (
           <MenuItem key={f.name} value={f.name} disabled={handleDisabled(f)}>
             {f.name}
           </MenuItem>
         ))}
+
       </Select>
     </>
   )
@@ -146,8 +163,57 @@ export const StyleSelector = ({
       onChange={e => {
         dispatch(setStyle({ styleName: e.target.value, number: index }))
       }}
+      MenuProps={MenuProps}
     >
       {menuItems}
     </Select>
   )
+}
+
+export const ArchetypeSelector = ({ index, includeBossArchetypes = false, includeUnselected = false }: { index: number, includeBossArchetypes?: boolean, includeUnselected?: boolean }) => {
+  const hero = useAppSelector(state => state.hero.hero)
+  const dispatch = useAppDispatch()
+
+  const selectedArchetypes = hero.archetypes.filter(a => a !== defaultArchetype)
+  const archetype = hero.archetypes[index]
+  let menuItems = archetypes.map(arch => (
+    <MenuItem
+      key={arch.name}
+      value={arch.name}
+      disabled={selectedArchetypes.includes(arch)}
+    >
+      {arch.name}
+    </MenuItem>
+  ))
+  if (includeUnselected) {
+    menuItems = [
+      <MenuItem
+        key={defaultArchetype.name}
+        value={defaultArchetype.name}
+      >
+        No Archetype
+      </MenuItem>, ...menuItems
+    ]
+  }
+  if (includeBossArchetypes) {
+    const bossMenuItems = bossArchetypes.map(arch => (
+      <MenuItem key={arch.name} value={arch.name}>
+        {arch.name}
+      </MenuItem>
+    ))
+    menuItems = [<ListSubheader>General</ListSubheader>, ...menuItems, <ListSubheader>Boss Archetypes</ListSubheader>, ...bossMenuItems]
+  }
+  return (<Select
+    value={archetype.name}
+    onChange={e => {
+      dispatch(
+        setArchetype({
+          archetypeName: e.target.value,
+          number: index,
+        }),
+      )
+    }}
+  >
+    {menuItems}
+  </Select>)
 }

--- a/src/app/textContent.ts
+++ b/src/app/textContent.ts
@@ -14,6 +14,7 @@ export const defaultForm: Form = {
     description: "",
   },
   actionDice: [],
+  forbiddenActionDice: [],
   actions: [],
 }
 export const forms: Form[] = [

--- a/src/app/textContent.ts
+++ b/src/app/textContent.ts
@@ -24,6 +24,7 @@ export const forms: Form[] = [
         "Your Actions may apply to one extra target within range. When you add Blaster Form to a Style, increase that Style's maximum range by 1",
     },
     actionDice: [Dice.d8, Dice.d8, Dice.d8],
+    forbiddenActionDice: [Dice.d8],
     name: "Blaster",
     rangeModifiers: [{ relMaxRange: 1 }],
     actions: [
@@ -60,6 +61,7 @@ export const forms: Form[] = [
         If you redirect an action you choose all targets and make all decisions for that action.`,
     },
     actionDice: [Dice.d10, Dice.d8, Dice.d6, Dice.d4],
+    forbiddenActionDice: [Dice.d8, Dice.d6],
     name: "Control",
     rangeModifiers: [{ relMaxRange: 3 }, { absMinRange: 1 }],
     actions: [
@@ -89,6 +91,7 @@ export const forms: Form[] = [
         "After you Throw or Grapple someone, you gain X Speed tokens, where X is how many spaces you moved them.\nAfter each space you move using Free Movement, you may choose someone within range and pull them 1 space",
     },
     actionDice: [Dice.d10, Dice.d8, Dice.d6],
+    forbiddenActionDice: [Dice.d8, Dice.d6],
     name: "Dance",
     actions: [
       {
@@ -114,6 +117,7 @@ export const forms: Form[] = [
         "You have Armor. When you gain Speed tokens, replace half of them (rounded up) with Iron tokens",
     },
     actionDice: [Dice.d8, Dice.d6, Dice.d6],
+    forbiddenActionDice: [Dice.d6, Dice.d6],
     name: "Iron",
     actions: [
       {
@@ -154,6 +158,7 @@ export const forms: Form[] = [
         "After you deal damage to an enemy with an Action, you hit them again for 1 damage",
     },
     actionDice: [Dice.d6, Dice.d6, Dice.d4, Dice.d4],
+    forbiddenActionDice: [Dice.d6, Dice.d4],
     name: "One-Two",
     actions: [
       {
@@ -183,6 +188,7 @@ export const forms: Form[] = [
         "When you gain Speed tokens, replace half of them (rounded up) with Power tokens.\nYou may spend up to 3 Power tokens per hit",
     },
     actionDice: [Dice.d10, Dice.d10, Dice.d4],
+    forbiddenActionDice: [Dice.d10, Dice.d4],
     name: "Power",
     actions: [
       {
@@ -218,6 +224,7 @@ export const forms: Form[] = [
         "You have Armor. You do not discard your Speed tokens at the end of a turn.\nYou may only take one Action per turn.\nYour Action Pool does not empty between Turns or Rounds",
     },
     actionDice: [Dice.d8, Dice.d8, Dice.d6, Dice.d4],
+    forbiddenActionDice: [Dice.d8, Dice.d4],
     name: "Reversal",
     actions: [
       {
@@ -239,6 +246,7 @@ export const forms: Form[] = [
         "At the start and end of your turn, you gain 2 Speed tokens\nYou do not discard your Speed tokens at the end of a turn.",
     },
     actionDice: [Dice.d4, Dice.d4, Dice.d4, Dice.d4, Dice.d4, Dice.d4],
+    forbiddenActionDice: [Dice.d4, Dice.d4, Dice.d4],
     name: "Shadow",
     actions: [
       {
@@ -265,6 +273,7 @@ export const forms: Form[] = [
         "At the start of each turn choose a song; Iron, Power or Speed. You gain three tokens of the chosen type and each of your allies gain 1 of that type",
     },
     actionDice: [Dice.d8, Dice.d6, Dice.d6, Dice.d4],
+    forbiddenActionDice: [Dice.d8, Dice.d4],
     name: "Song",
     actions: [
       {
@@ -295,6 +304,7 @@ export const forms: Form[] = [
         "At the start of your turn, either heal or discard one token you hold. At the end of your turn, choose an enemy in range and give them one Weakness token",
     },
     actionDice: [Dice.d6, Dice.d6, Dice.d6, Dice.d6],
+    forbiddenActionDice: [Dice.d6, Dice.d6],
     name: "Vigilance",
     actions: [
       {
@@ -332,6 +342,7 @@ export const forms: Form[] = [
         "At the start of your turn, for each of these that is true, add 1d6 to your Action Dice\n-Your current Health Bar is at half HP or less\n-Someone on your team is Taken Out\n-You are holding a non-basic Token",
     },
     actionDice: [Dice.d10, Dice.d6, Dice.d6],
+    forbiddenActionDice: [Dice.d10],
     name: "Wild",
     actions: [
       {
@@ -358,6 +369,7 @@ export const forms: Form[] = [
         "Your Action Pool is predetermined: 7, 5, 3, 1. You may hold multiple Shields at a time. Only one Shield is active at a time. When your active Shield breaks, your next Shield doesn't become active until the end of the current turn.\nWhen an enemy damages or breaks your Shield, you deal 1 damage to them",
     },
     actionDice: [7, 5, 3, 1],
+    forbiddenActionDice: [5, 3],
     name: "Zen",
     actions: [
       {
@@ -2103,7 +2115,7 @@ export const styles: Style[] = [
     maxRange: 2,
     ability: {
       description:
-        "At the start of your turn, you take 2 damage. This damage cannot drop you below 1 HP on your current Health Bar.\nThis Style is attached to two Forms. You have the Abilities and Unique Actions from each Form. Do not use the Action Dicelisted in those Forms. This Stance's Action Dice are determined by combining the results of the following chart:\nBlaster: d8            Reversal: d8 d4\nControl: d8 d6       Shadow: d4 d4 d4\nDance: d8 d6        Song: d8 d4\nIron: d6 d6            Vigilance: d6 d6\nOne-Two: d6 d4    Wild: d10\nPower: d10 d4       Zen: 5 3",
+        "At the start of your turn, you take 2 damage. This damage cannot drop you below 1 HP on your current Health Bar.",
     },
     actions: [],
   },

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -47,7 +47,8 @@ export interface Form {
   key: string
   name: string
   ability: Ability
-  actionDice: Dice[] | number[]
+  actionDice: (Dice | number)[]
+  forbiddenActionDice: (Dice | number)[]
   actions: Action[]
   rangeModifiers?: FormRangeModifier[]
   // TODO skills, though not hugely important

--- a/src/features/hero/heroSlice.ts
+++ b/src/features/hero/heroSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit"
 import type { PayloadAction } from "@reduxjs/toolkit"
 import type { RootState } from "../../app/store"
-import type { Build, Hero } from "../../app/types"
+import type { Build, Form, Hero } from "../../app/types"
 import { CharacterType } from "../../app/types"
 import { HeroType } from "../../app/types"
 import {
@@ -36,7 +36,8 @@ interface StyleUpdate {
   number: number
 }
 interface FormUpdate {
-  formName: string
+  formName?: string
+  form?: Form
   number: number
 }
 export const serializeHero = (hero: Hero): string[] => {
@@ -57,12 +58,16 @@ export const serializeHero = (hero: Hero): string[] => {
   ]
 }
 export const deserializeHero = (serialized: string[]): Hero => {
-  const resolveArchetype = (archName: string) =>
-    archetypes.find(a => a.key === archName) ?? defaultArchetype
-  const resolveStyle = (styleName: string) =>
-    styles.find(s => s.key === styleName) ?? defaultStyle
-  const resolveForm = (formName: string) =>
-    forms.find(f => f.key === formName) ?? defaultForm
+  const resolveArchetype = (archKey: string) =>
+    archetypes.find(a => a.key === archKey) ?? defaultArchetype
+  const resolveStyle = (styleKey: string) =>
+    styles.find(s => s.key === styleKey) ?? defaultStyle
+  const resolveForm = (formKey: string) => {
+    if (formKey.startsWith("f-")) {
+      return deserializeForbiddenForm(formKey)
+    }
+    return forms.find(f => f.key === formKey) ?? defaultForm
+  }
   return {
     characterType:
       CharacterType[serialized[0] as keyof typeof CharacterType] ??
@@ -87,6 +92,43 @@ export const deserializeHero = (serialized: string[]): Hero => {
     ],
     selectedFormIndex: 0,
     selectedStyleIndex: 0,
+  }
+}
+
+export const deserializeForbiddenForm = (key: string): Form => {
+  const [form1, form2] = splitForms(key)
+  if (form1 && form2) {
+    return combineForms(form1, form2)
+  }
+  console.error("Invalid forbidden form key", key)
+  return defaultForm
+}
+
+export const splitForms = (
+  key: string,
+): [Form | undefined, Form | undefined] => {
+  const [_f, key1, key2] = key.split("-") // eslint-disable-line @typescript-eslint/no-unused-vars
+
+  const form1 = forms.find(f => f.key === key1)
+  const form2 = forms.find(f => f.key === key2)
+
+  return [form1, form2]
+}
+
+export const combineForms = (f1: Form, f2: Form): Form => {
+  return {
+    key: `f-${f1.key}-${f2.key}`,
+    name: `${f1.name}/${f2.name}`,
+    actionDice: [...f1.forbiddenActionDice, ...f2.forbiddenActionDice],
+    forbiddenActionDice: [],
+    ability: {
+      description: `${f1.name}: ${f1.ability.description}. ${f2.name}: ${f2.ability.description}`,
+    },
+    actions: [...f1.actions, ...f2.actions],
+    rangeModifiers: [
+      ...(f1.rangeModifiers ?? []),
+      ...(f2.rangeModifiers ?? []),
+    ],
   }
 }
 export const heroSlice = createSlice({
@@ -138,9 +180,13 @@ export const heroSlice = createSlice({
       }
     },
     setForm: (state, action: PayloadAction<FormUpdate>) => {
-      const formForName = forms.find(v => v.name === action.payload.formName)
-      if (formForName !== undefined) {
-        state.forms[action.payload.number] = formForName
+      if (action.payload.formName !== undefined) {
+        const formForName = forms.find(v => v.name === action.payload.formName)
+        if (formForName !== undefined) {
+          state.forms[action.payload.number] = formForName
+        }
+      } else if (action.payload.form !== undefined) {
+        state.forms[action.payload.number] = action.payload.form
       }
     },
     setSelectedStyle: (state, action: PayloadAction<number>) => {


### PR DESCRIPTION
Add support for Forbidden stances by building one from it's two sub-forms.
- Removed some of the text about how forbidden stances work.
- A second form selector appears when the forbidden style is chosen

This also prompted some refactoring to share components, which in turn prompted some UI reshuffling. The resulting modal is a bit more compact, but hopefully just as readable.